### PR TITLE
Fix HSL rounding + missing alpha in hex

### DIFF
--- a/src/main/java/org/silentsoft/csscolor4j/Color.java
+++ b/src/main/java/org/silentsoft/csscolor4j/Color.java
@@ -1,6 +1,7 @@
 package org.silentsoft.csscolor4j;
 
 import java.math.BigDecimal;
+import java.util.Locale;
 import java.util.Objects;
 
 public class Color {
@@ -91,7 +92,12 @@ public class Color {
             }
         }
 
-        color.hex = String.format("#%02x%02x%02x", red, green, blue);
+        if (opacity == 1) {
+            color.hex = String.format(Locale.ROOT, "#%02x%02x%02x", red, green, blue);
+        } else {
+            color.hex = String.format(Locale.ROOT, "#%02x%02x%02x%02x", red, green, blue,
+                    (int) Math.round(opacity * 255));
+        }
 
         return color;
     }

--- a/src/main/java/org/silentsoft/csscolor4j/Color.java
+++ b/src/main/java/org/silentsoft/csscolor4j/Color.java
@@ -269,7 +269,7 @@ public class Color {
      */
     public static Color valueOf(String value) throws IllegalArgumentException {
         value = value.trim().toLowerCase(Locale.ROOT);
-
+        NamedColor namedColor;
         if (value.contains("rgb")) {
             String[] rgb = split(value);
             if (rgb[0].contains("%") || rgb[1].contains("%") || rgb[2].contains("%")) {
@@ -301,8 +301,8 @@ public class Color {
             double opacity = hsl.length >= 4 ? parseDouble(hsl[3], 1) : 1.0;
 
             return hsl(hue, saturation, lightness, opacity);
-        } else if (NamedColor.nameOf(value) != null) {
-            return hex(NamedColor.nameOf(value).getHex());
+        } else if ((namedColor = NamedColor.nameOf(value)) != null) {
+            return hex(namedColor.getHex());
         } else if ("transparent".equals(value)) {
             return rgb(0, 0, 0, 0);
         } else if (value.startsWith("#") || value.length() == 3 || value.length() == 4 ||  value.length() == 6 || value.length() == 8) {

--- a/src/main/java/org/silentsoft/csscolor4j/Color.java
+++ b/src/main/java/org/silentsoft/csscolor4j/Color.java
@@ -416,7 +416,7 @@ public class Color {
     private static double parseDouble(String value, double limit) {
         boolean hasPercent = value.contains("%");
         value = value.replace("%", "").trim();
-        double number = Double.valueOf(value);
+        double number = Double.parseDouble(value);
         return hasPercent ? BigDecimal.valueOf(number).multiply(BigDecimal.valueOf((limit / 100.0))).doubleValue() : number;
     }
 
@@ -436,13 +436,13 @@ public class Color {
     private static double toDegrees(String value) {
         value = value.toLowerCase(Locale.ROOT).trim();
         if (value.contains("deg")) {
-            return Double.valueOf(value.replace("deg", "").trim());
+            return Double.parseDouble(value.replace("deg", "").trim());
         } else if (value.contains("grad")) {
-            return (Double.valueOf(value.replace("grad", "").trim()) / 400.0) * 360.0;
+            return (Double.parseDouble(value.replace("grad", "").trim()) / 400.0) * 360.0;
         } else if (value.contains("rad")) {
-            return Double.valueOf(value.replace("rad", "").trim()) * (180.0 / Math.PI);
+            return Double.parseDouble(value.replace("rad", "").trim()) * (180.0 / Math.PI);
         } else if (value.contains("turn")) {
-            return Double.valueOf(value.replace("turn", "").trim()) * 360.0;
+            return Double.parseDouble(value.replace("turn", "").trim()) * 360.0;
         }
         return parseDouble(value, 360);
     }

--- a/src/main/java/org/silentsoft/csscolor4j/Color.java
+++ b/src/main/java/org/silentsoft/csscolor4j/Color.java
@@ -171,9 +171,9 @@ public class Color {
         }
         double _m = lightness - (_c / 2);
 
-        int red = (int)((_rgb[0] + _m) * 255);
-        int green = (int)((_rgb[1] + _m) * 255);
-        int blue = (int)((_rgb[2] + _m) * 255);
+        int red = (int) Math.round((_rgb[0] + _m) * 255);
+        int green = (int) Math.round((_rgb[1] + _m) * 255);
+        int blue = (int) Math.round((_rgb[2] + _m) * 255);
 
         Color color = rgb(red, green, blue, opacity);
         color.hue = hue;

--- a/src/main/java/org/silentsoft/csscolor4j/Color.java
+++ b/src/main/java/org/silentsoft/csscolor4j/Color.java
@@ -268,7 +268,7 @@ public class Color {
      * @see #hex(String)
      */
     public static Color valueOf(String value) throws IllegalArgumentException {
-        value = value.trim().toLowerCase();
+        value = value.trim().toLowerCase(Locale.ROOT);
 
         if (value.contains("rgb")) {
             String[] rgb = split(value);
@@ -434,7 +434,7 @@ public class Color {
     }
 
     private static double toDegrees(String value) {
-        value = value.toLowerCase().trim();
+        value = value.toLowerCase(Locale.ROOT).trim();
         if (value.contains("deg")) {
             return Double.valueOf(value.replace("deg", "").trim());
         } else if (value.contains("grad")) {

--- a/src/main/java/org/silentsoft/csscolor4j/Color.java
+++ b/src/main/java/org/silentsoft/csscolor4j/Color.java
@@ -92,11 +92,11 @@ public class Color {
             }
         }
 
-        if (opacity == 1) {
+        int alpha = (int) Math.round(opacity * 255);
+        if (alpha >= 255) {
             color.hex = String.format(Locale.ROOT, "#%02x%02x%02x", red, green, blue);
         } else {
-            color.hex = String.format(Locale.ROOT, "#%02x%02x%02x%02x", red, green, blue,
-                    (int) Math.round(opacity * 255));
+            color.hex = String.format(Locale.ROOT, "#%02x%02x%02x%02x", red, green, blue, Math.max(0, alpha));
         }
 
         return color;

--- a/src/test/java/org/silentsoft/csscolor4j/ColorTest.java
+++ b/src/test/java/org/silentsoft/csscolor4j/ColorTest.java
@@ -121,6 +121,8 @@ public class ColorTest {
     @Test
     public void hexTest() {
         Assertions.assertEquals("#ffffff", Color.valueOf("rgb(255, 255, 255)").getHex());
+        Assertions.assertEquals("#ffffff", Color.valueOf("rgba(255, 255, 255, 1.0)").getHex());
+        Assertions.assertEquals("#ffffff80", Color.valueOf("rgba(255, 255, 255, 0.5)").getHex());
 
         Assertions.assertEquals("#9cf", Color.valueOf("9cf").getHex());
         Assertions.assertEquals("#9cf", Color.valueOf("#9cf").getHex());

--- a/src/test/java/org/silentsoft/csscolor4j/ColorTest.java
+++ b/src/test/java/org/silentsoft/csscolor4j/ColorTest.java
@@ -308,6 +308,7 @@ public class ColorTest {
         Assertions.assertEquals(Color.WHEAT, Color.valueOf("wheat"));
         Assertions.assertEquals(Color.WHITESMOKE, Color.valueOf("whitesmoke"));
         Assertions.assertEquals(Color.YELLOWGREEN, Color.valueOf("yellowgreen"));
+        Assertions.assertEquals(Color.REBECCAPURPLE, Color.valueOf("rebeccapurple"));
     }
 
     private void assertRGB(Color color, int red, int green, int blue) {

--- a/src/test/java/org/silentsoft/csscolor4j/ColorTest.java
+++ b/src/test/java/org/silentsoft/csscolor4j/ColorTest.java
@@ -92,6 +92,11 @@ public class ColorTest {
     }
 
     @Test
+    public void hslRoundingTest() {
+        Assertions.assertEquals("#c678dd", Color.valueOf("hsl(286, 60%, 67%)").getHex());
+    }
+
+    @Test
     public void cmykTest() {
         Color cyan = Color.valueOf("cmyk(1, 0, 0, 0)");
         assertCMYK(cyan, 1, 0, 0, 0);

--- a/src/test/java/org/silentsoft/csscolor4j/ColorTest.java
+++ b/src/test/java/org/silentsoft/csscolor4j/ColorTest.java
@@ -127,7 +127,10 @@ public class ColorTest {
     public void hexTest() {
         Assertions.assertEquals("#ffffff", Color.valueOf("rgb(255, 255, 255)").getHex());
         Assertions.assertEquals("#ffffff", Color.valueOf("rgba(255, 255, 255, 1.0)").getHex());
+        Assertions.assertEquals("#ffffff00", Color.valueOf("rgba(255, 255, 255, 0)").getHex());
         Assertions.assertEquals("#ffffff80", Color.valueOf("rgba(255, 255, 255, 0.5)").getHex());
+        Assertions.assertEquals("#ffffff", Color.valueOf("rgba(255, 255, 255, 1.5)").getHex());
+        Assertions.assertEquals("#ffffff00", Color.valueOf("rgba(255, 255, 255, -0.5)").getHex());
 
         Assertions.assertEquals("#9cf", Color.valueOf("9cf").getHex());
         Assertions.assertEquals("#9cf", Color.valueOf("#9cf").getHex());


### PR DESCRIPTION
1. Fixes HSL rounding mentioned in https://github.com/silentsoft/csscolor4j/issues/1
2. Fixes missing alpha value in hex
3. Minor cleanups (unnecessary boxed `Double`, `Locale.ROOT` for string handling, unnecessary twice lookup for `NamedColor`)
4. Added tests, and all tests are passing